### PR TITLE
Updating to POMDPTools

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,14 +4,14 @@ repo = "https://github.com/JuliaPOMDP/POMDPFiles.jl"
 version = "0.2.3"
 
 [deps]
-POMDPModelTools = "08074719-1b2a-587c-a292-00f91cc44415"
+POMDPTools = "7588e00f-9cae-40de-98dc-e0c70c48cdd7"
 POMDPXFiles = "c6f6ee83-58c6-5336-a19f-2c76817e1af6"
 POMDPs = "a93abf59-7444-517b-a68a-c42f96afdd7d"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
-POMDPModelTools = "0.2, 0.3"
+POMDPTools = "0.1"
 POMDPXFiles = "0.2"
 POMDPs = "0.9"
 Reexport = "0.2, 1"


### PR DESCRIPTION
`POMDPModelTools` was renamed to `POMDPTools`. To ensure future compatibility, `POMDPFiles` needs to use `POMDPTools`.

I'm not certain of `POMDPTools` entry in `[compat]`, but since `POMDPModelTools` had an entry, I added it.